### PR TITLE
Don't use passes sub-package in tests

### DIFF
--- a/src/test/scala/firrtlTests/LoweringCompilersSpec.scala
+++ b/src/test/scala/firrtlTests/LoweringCompilersSpec.scala
@@ -5,7 +5,6 @@ package firrtlTests
 import org.scalatest.{FlatSpec, Matchers}
 
 import firrtl._
-import firrtl.passes
 import firrtl.options.Dependency
 import firrtl.stage.{Forms, TransformManager}
 import firrtl.transforms.IdentityTransform
@@ -37,75 +36,75 @@ class LoweringCompilersSpec extends FlatSpec with Matchers {
 
   def legacyTransforms(a: CoreTransform): Seq[Transform] = a match {
     case _: ChirrtlToHighFirrtl => Seq(
-      passes.CheckChirrtl,
-      passes.CInferTypes,
-      passes.CInferMDir,
-      passes.RemoveCHIRRTL)
-    case _: IRToWorkingIR => Seq(passes.ToWorkingIR)
+      firrtl.passes.CheckChirrtl,
+      firrtl.passes.CInferTypes,
+      firrtl.passes.CInferMDir,
+      firrtl.passes.RemoveCHIRRTL)
+    case _: IRToWorkingIR => Seq(firrtl.passes.ToWorkingIR)
     case _: ResolveAndCheck => Seq(
-      passes.CheckHighForm,
-      passes.ResolveKinds,
-      passes.InferTypes,
-      passes.CheckTypes,
-      passes.Uniquify,
-      passes.ResolveKinds,
-      passes.InferTypes,
-      passes.ResolveFlows,
-      passes.CheckFlows,
-      new passes.InferBinaryPoints,
-      new passes.TrimIntervals,
-      new passes.InferWidths,
-      passes.CheckWidths,
+      firrtl.passes.CheckHighForm,
+      firrtl.passes.ResolveKinds,
+      firrtl.passes.InferTypes,
+      firrtl.passes.CheckTypes,
+      firrtl.passes.Uniquify,
+      firrtl.passes.ResolveKinds,
+      firrtl.passes.InferTypes,
+      firrtl.passes.ResolveFlows,
+      firrtl.passes.CheckFlows,
+      new firrtl.passes.InferBinaryPoints,
+      new firrtl.passes.TrimIntervals,
+      new firrtl.passes.InferWidths,
+      firrtl.passes.CheckWidths,
       new firrtl.transforms.InferResets)
     case _: HighFirrtlToMiddleFirrtl => Seq(
-      passes.PullMuxes,
-      passes.ReplaceAccesses,
-      passes.ExpandConnects,
-      passes.ZeroLengthVecs,
-      passes.RemoveAccesses,
-      passes.Uniquify,
-      passes.ExpandWhens,
-      passes.CheckInitialization,
-      passes.ResolveKinds,
-      passes.InferTypes,
-      passes.CheckTypes,
-      passes.ResolveFlows,
-      new passes.InferWidths,
-      passes.CheckWidths,
-      new passes.RemoveIntervals,
-      passes.ConvertFixedToSInt,
-      passes.ZeroWidth,
-      passes.InferTypes)
+      firrtl.passes.PullMuxes,
+      firrtl.passes.ReplaceAccesses,
+      firrtl.passes.ExpandConnects,
+      firrtl.passes.ZeroLengthVecs,
+      firrtl.passes.RemoveAccesses,
+      firrtl.passes.Uniquify,
+      firrtl.passes.ExpandWhens,
+      firrtl.passes.CheckInitialization,
+      firrtl.passes.ResolveKinds,
+      firrtl.passes.InferTypes,
+      firrtl.passes.CheckTypes,
+      firrtl.passes.ResolveFlows,
+      new firrtl.passes.InferWidths,
+      firrtl.passes.CheckWidths,
+      new firrtl.passes.RemoveIntervals,
+      firrtl.passes.ConvertFixedToSInt,
+      firrtl.passes.ZeroWidth,
+      firrtl.passes.InferTypes)
     case _: MiddleFirrtlToLowFirrtl => Seq(
-      passes.LowerTypes,
-      passes.ResolveKinds,
-      passes.InferTypes,
-      passes.ResolveFlows,
-      new passes.InferWidths,
-      passes.Legalize,
+      firrtl.passes.LowerTypes,
+      firrtl.passes.ResolveKinds,
+      firrtl.passes.InferTypes,
+      firrtl.passes.ResolveFlows,
+      new firrtl.passes.InferWidths,
+      firrtl.passes.Legalize,
       firrtl.transforms.RemoveReset,
-      passes.ResolveFlows,
+      firrtl.passes.ResolveFlows,
       new firrtl.transforms.CheckCombLoops,
       new checks.CheckResets,
       new firrtl.transforms.RemoveWires)
     case _: LowFirrtlOptimization => Seq(
-      passes.RemoveValidIf,
+      firrtl.passes.RemoveValidIf,
       new firrtl.transforms.ConstantPropagation,
-      passes.PadWidths,
+      firrtl.passes.PadWidths,
       new firrtl.transforms.ConstantPropagation,
-      passes.Legalize,
-      passes.memlib.VerilogMemDelays, // TODO move to Verilog emitter
+      firrtl.passes.Legalize,
+      firrtl.passes.memlib.VerilogMemDelays, // TODO move to Verilog emitter
       new firrtl.transforms.ConstantPropagation,
-      passes.SplitExpressions,
+      firrtl.passes.SplitExpressions,
       new firrtl.transforms.CombineCats,
-      passes.CommonSubexpressionElimination,
+      firrtl.passes.CommonSubexpressionElimination,
       new firrtl.transforms.DeadCodeElimination)
     case _: MinimumLowFirrtlOptimization => Seq(
-      passes.RemoveValidIf,
-      passes.PadWidths,
-      passes.Legalize,
-      passes.memlib.VerilogMemDelays, // TODO move to Verilog emitter
-      passes.SplitExpressions)
+      firrtl.passes.RemoveValidIf,
+      firrtl.passes.PadWidths,
+      firrtl.passes.Legalize,
+      firrtl.passes.memlib.VerilogMemDelays, // TODO move to Verilog emitter
+      firrtl.passes.SplitExpressions)
   }
 
   def compare(a: Seq[Transform], b: TransformManager, patches: Seq[PatchAction] = Seq.empty): Unit = {

--- a/src/test/scala/firrtlTests/RemoveWiresSpec.scala
+++ b/src/test/scala/firrtlTests/RemoveWiresSpec.scala
@@ -163,7 +163,7 @@ class RemoveWiresSpec extends FirrtlFlatSpec {
       |c <= n""".stripMargin
     )
     // Check declaration before use is maintained
-    passes.CheckHighForm.execute(result)
+    firrtl.passes.CheckHighForm.execute(result)
   }
 
   it should "order registers with async reset correctly" in {
@@ -180,7 +180,7 @@ class RemoveWiresSpec extends FirrtlFlatSpec {
       |""".stripMargin
     )
     // Check declaration before use is maintained
-    passes.CheckHighForm.execute(result)
+    firrtl.passes.CheckHighForm.execute(result)
   }
 
   it should "order registers respecting initializations" in {
@@ -195,7 +195,7 @@ class RemoveWiresSpec extends FirrtlFlatSpec {
           |bar <= y
           |""".stripMargin)
     // Check declaration before use is maintained
-    passes.CheckHighForm.execute(result)
+    firrtl.passes.CheckHighForm.execute(result)
   }
 
 }


### PR DESCRIPTION
This changes two test files using the "passes" sub-package to
"firrtl.passes". This allows a new "firrtlTests.passes" package to be
freely created and used without a name collision.

Signed-off-by: Schuyler Eldridge <schuyler.eldridge@ibm.com>